### PR TITLE
Small adjustments for senseme

### DIFF
--- a/custom_components/senseme/__init__.py
+++ b/custom_components/senseme/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONF_INFO, DOMAIN, UPDATE_RATE
 
@@ -34,37 +34,49 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up SenseME from a config entry."""
+    hass.data[DOMAIN][entry.entry_id] = {}
 
-    async def _setup_platforms():
-        """Set up platforms and initiate connection."""
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_setup(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-
-    hass.data[DOMAIN][entry.unique_id] = {}
     status, device = await async_get_device_by_device_info(
         info=entry.data[CONF_INFO], start_first=True, refresh_minutes=UPDATE_RATE
     )
+
     if not status:
         _LOGGER.warning(
             "%s: Connect to address %s failed",
             device.name,
             device.address,
         )
+        raise ConfigEntryNotReady
+
     await device.async_update(not status)
-    hass.data[DOMAIN][entry.unique_id][CONF_DEVICE] = device
-    hass.async_create_task(_setup_platforms())
+
+    hass.data[DOMAIN][entry.entry_id][CONF_DEVICE] = device
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    hass.data[DOMAIN][entry.unique_id][CONF_DEVICE].stop()
-    hass.data[DOMAIN][entry.unique_id] = None
-    return True
+    hass.data[DOMAIN][entry.entry_id][CONF_DEVICE].stop()
+
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
 
 
 class SensemeEntity:
@@ -85,6 +97,7 @@ class SensemeEntity:
             "manufacturer": "Big Ass Fans",
             "model": self._device.model,
             "sw_version": self._device.fw_version,
+            "suggested_area": self._device.room_name,
         }
 
     @property
@@ -109,3 +122,11 @@ class SensemeEntity:
     def name(self) -> str:
         """Get name."""
         return self._name
+
+    async def async_added_to_hass(self):
+        """Add data updated listener after this object has been initialized."""
+        self._device.add_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self):
+        """Remove data updated listener after this object has been initialized."""
+        self._device.remove_callback(self.async_write_ha_state)

--- a/custom_components/senseme/binary_sensor.py
+++ b/custom_components/senseme/binary_sensor.py
@@ -9,18 +9,16 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_DEVICE
 
 from . import SensemeEntity
-from .const import CONF_BINARY_SENSOR, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SenseME occupancy sensors."""
-    device = hass.data[DOMAIN][entry.unique_id][CONF_DEVICE]
+    device = hass.data[DOMAIN][entry.entry_id][CONF_DEVICE]
     if device.has_sensor:
-        binary_sensor = HASensemeOccupancySensor(device)
-        hass.data[DOMAIN][entry.unique_id][CONF_BINARY_SENSOR] = binary_sensor
-        hass.add_job(async_add_entities, [binary_sensor])
+        async_add_entities([HASensemeOccupancySensor(device)])
 
 
 class HASensemeOccupancySensor(SensemeEntity, BinarySensorEntity):

--- a/custom_components/senseme/binary_sensor.py
+++ b/custom_components/senseme/binary_sensor.py
@@ -9,18 +9,16 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_DEVICE
 
 from . import SensemeEntity
-from .const import CONF_BINARY_SENSOR, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SenseME occupancy sensors."""
-    device = hass.data[DOMAIN][entry.unique_id][CONF_DEVICE]
+    device = hass.data[DOMAIN][entry.entry_id][CONF_DEVICE]
     if device.has_sensor:
-        binary_sensor = HASensemeOccupancySensor(device)
-        hass.data[DOMAIN][entry.unique_id][CONF_BINARY_SENSOR] = binary_sensor
-        hass.add_job(async_add_entities, [binary_sensor])
+        async_add_entities([HASensemeOccupancySensor(device)])
 
 
 class HASensemeOccupancySensor(SensemeEntity, BinarySensorEntity):
@@ -29,10 +27,6 @@ class HASensemeOccupancySensor(SensemeEntity, BinarySensorEntity):
     def __init__(self, device: SensemeDevice):
         """Initialize the entity."""
         super().__init__(device, f"{device.name} Occupancy")
-
-    async def async_added_to_hass(self):
-        """Add data updated listener after this object has been initialized."""
-        self._device.add_callback(self.async_write_ha_state)
 
     @property
     def unique_id(self):

--- a/custom_components/senseme/const.py
+++ b/custom_components/senseme/const.py
@@ -15,11 +15,12 @@ CONF_DEVICE_INPUT = "device_input"
 
 # data storage
 CONF_INFO = "info"
-CONF_FAN = "fan"
-CONF_LIGHT = "light"
-CONF_BINARY_SENSOR = "binary_sensor"
 
 # Fan Preset Modes
 PRESET_MODE_NONE = "None"
 PRESET_MODE_WHOOSH = "Whoosh"
 PRESET_MODE_SLEEP = "Sleep"
+
+# Fan Directions
+SENSEME_DIRECTION_FORWARD = "FWD"
+SENSEME_DIRECTION_REVERSE = "REV"

--- a/custom_components/senseme/fan.py
+++ b/custom_components/senseme/fan.py
@@ -19,21 +19,20 @@ from homeassistant.util.percentage import (
 
 from . import SensemeEntity
 from .const import (
-    CONF_FAN,
     DOMAIN,
     PRESET_MODE_NONE,
     PRESET_MODE_SLEEP,
     PRESET_MODE_WHOOSH,
+    SENSEME_DIRECTION_FORWARD,
+    SENSEME_DIRECTION_REVERSE,
 )
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SenseME fans."""
-    device = hass.data[DOMAIN][entry.unique_id][CONF_DEVICE]
+    device = hass.data[DOMAIN][entry.entry_id][CONF_DEVICE]
     if device.is_fan:
-        fan = HASensemeFan(device)
-        hass.data[DOMAIN][entry.unique_id][CONF_FAN] = fan
-        hass.add_job(async_add_entities, [fan])
+        async_add_entities([HASensemeFan(device)])
 
 
 class HASensemeFan(SensemeEntity, FanEntity):
@@ -71,7 +70,7 @@ class HASensemeFan(SensemeEntity, FanEntity):
     def current_direction(self) -> str:
         """Return the fan direction."""
         direction = self._device.fan_dir
-        if direction == "FWD":
+        if direction == SENSEME_DIRECTION_FORWARD:
             return DIRECTION_FORWARD
         return DIRECTION_REVERSE
 
@@ -80,6 +79,11 @@ class HASensemeFan(SensemeEntity, FanEntity):
         """Flag supported features."""
         supported_features = SUPPORT_SET_SPEED | SUPPORT_DIRECTION
         return supported_features
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds."""
+        return self._device.fan_speed_limits[1]
 
     @property
     def percentage(self) -> str:
@@ -146,6 +150,6 @@ class HASensemeFan(SensemeEntity, FanEntity):
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         if direction == DIRECTION_FORWARD:
-            self._device.fan_dir = "FWD"
+            self._device.fan_dir = SENSEME_DIRECTION_FORWARD
         else:
-            self._device.fan_dir = "REV"
+            self._device.fan_dir = SENSEME_DIRECTION_REVERSE

--- a/custom_components/senseme/light.py
+++ b/custom_components/senseme/light.py
@@ -12,18 +12,16 @@ from homeassistant.components.light import (
 from homeassistant.const import CONF_DEVICE
 
 from . import SensemeEntity
-from .const import CONF_LIGHT, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SenseME lights."""
-    device = hass.data[DOMAIN][entry.unique_id][CONF_DEVICE]
+    device = hass.data[DOMAIN][entry.entry_id][CONF_DEVICE]
     if device.has_light:
-        light = HASensemeLight(device)
-        hass.data[DOMAIN][entry.unique_id][CONF_LIGHT] = light
-        hass.add_job(async_add_entities, [light])
+        async_add_entities([HASensemeLight(device)])
 
 
 class HASensemeLight(SensemeEntity, LightEntity):
@@ -40,10 +38,6 @@ class HASensemeLight(SensemeEntity, LightEntity):
         self._supported_features = SUPPORT_BRIGHTNESS
         if device.is_light:
             self._supported_features |= SUPPORT_COLOR_TEMP
-
-    async def async_added_to_hass(self):
-        """Add data updated listener after this object has been initialized."""
-        self._device.add_callback(self.async_write_ha_state)
 
     @property
     def device_state_attributes(self) -> dict:

--- a/custom_components/senseme/light.py
+++ b/custom_components/senseme/light.py
@@ -12,18 +12,16 @@ from homeassistant.components.light import (
 from homeassistant.const import CONF_DEVICE
 
 from . import SensemeEntity
-from .const import CONF_LIGHT, DOMAIN
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up SenseME lights."""
-    device = hass.data[DOMAIN][entry.unique_id][CONF_DEVICE]
+    device = hass.data[DOMAIN][entry.entry_id][CONF_DEVICE]
     if device.has_light:
-        light = HASensemeLight(device)
-        hass.data[DOMAIN][entry.unique_id][CONF_LIGHT] = light
-        hass.add_job(async_add_entities, [light])
+        async_add_entities([HASensemeLight(device)])
 
 
 class HASensemeLight(SensemeEntity, LightEntity):


### PR DESCRIPTION
- Retry setup later if the fan is offline
- Call async_add_entities directly
- Comply with standard to not store entities in a shared container
- Use standard entry.entry_id instead of entry.unique_id
- Use constants for forward/reverse
- Add speed_count to fan entity
- Add suggested_area to device info
- Ensure all platforms are unloaded
- Remove callback when entity is removed from hass