### PR TITLE
Avoid manual entry in the config flow with discovery

### DIFF
--- a/custom_components/senseme/config_flow.py
+++ b/custom_components/senseme/config_flow.py
@@ -2,13 +2,16 @@
 import ipaddress
 import logging
 
-import voluptuous as vol
 from aiosenseme import async_get_device_by_ip_address, discover_all
 from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+import voluptuous as vol
 
 from .const import CONF_DEVICE_INPUT, CONF_INFO, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+DISCOVER_TIMEOUT = 5
 
 
 class SensemeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -17,71 +20,68 @@ class SensemeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
-    def _devices_str(self):
-        """Return a human readable form of all discovered devices."""
-        return ", ".join(
-            [
-                f"`{device.name} ({device.address})`"
-                for device in self._discovered_devices
-                if device.uuid not in self._async_current_ids()
-            ]
-        )
-
-    def _prefill_identifier(self):
-        """Return IP address of one device that has not been paired with."""
-        for device in self._discovered_devices:
-            if device.uuid not in self._async_current_ids():
-                return str(device.address)
-        return ""
-
     def __init__(self) -> None:
         """Initialize the SenseME config flow."""
-        self.config = None
-        self._title = "SenseME"
         self._discovered_devices = None
+
+    async def _async_entry_for_device(self, device):
+        """Create a config entry for a device."""
+        await self.async_set_unique_id(device.uuid)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=device.name,
+            data={CONF_INFO: device.get_device_info},
+        )
+
+    async def async_step_manual(self, user_input=None):
+        """Handle manual entry of an ip address."""
+        errors = {}
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            try:
+                ipaddress.ip_address(host)
+            except ValueError:
+                errors[CONF_HOST] = "invalid_host"
+            else:
+                device = await async_get_device_by_ip_address(host)
+                if device is not None:
+                    return await self._async_entry_for_device(device)
+
+                errors[CONF_HOST] = "cannot_connect"
+
+        return self.async_show_form(
+            step_id="manual",
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            errors=errors,
+        )
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         # start discovery the first time through
         if self._discovered_devices is None:
-            self._discovered_devices = await discover_all(5)
-        device_list = self._devices_str()
-        default_suggestion = self._prefill_identifier()
-        errors = {}
+            self._discovered_devices = await discover_all(DISCOVER_TIMEOUT)
+
+        current_ids = self._async_current_ids()
+        device_selection = {
+            device.address: device.name
+            for device in self._discovered_devices
+            if device.uuid not in current_ids
+        }
+
+        if not device_selection:
+            return await self.async_step_manual()
+
+        device_selection[None] = None
+
         if user_input is not None:
-            device_name = user_input[CONF_DEVICE_INPUT]
-            selected_device = None
-            # see if device was already discovered
+            if CONF_HOST not in user_input:
+                return await self.async_step_manual()
+
             for device in self._discovered_devices:
-                if device == device_name:
-                    selected_device = device
-                    break
-            if selected_device is None:
-                try:
-                    # do some checking on IP address
-                    ipaddress.ip_address(device_name)
-                    selected_device = await async_get_device_by_ip_address(device_name)
-                except ValueError:
-                    _LOGGER.debug("Config flow invalid IP address %s", user_input)
-                    pass
-            if selected_device is None:
-                _LOGGER.debug("Config flow unable to connect to %s", user_input)
-                errors["base"] = "no_devices_found"
-            elif selected_device.uuid in self._async_current_ids():
-                _LOGGER.debug("Config flow entity already configured %s", user_input)
-                errors["base"] = "already_configured"
-            else:
-                await self.async_set_unique_id(selected_device.uuid)
-                _LOGGER.debug("Config flow adding new entity %s", user_input)
-                return self.async_create_entry(
-                    title=selected_device.name,
-                    data={CONF_INFO: selected_device.get_device_info},
-                )
+                if device.address == user_input[CONF_HOST]:
+                    return await self._async_entry_for_device(device)
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {vol.Required(CONF_DEVICE_INPUT, default=default_suggestion): str}
-            ),
-            errors=errors,
-            description_placeholders={"devices": device_list},
+            data_schema=vol.Schema({vol.Optional(CONF_HOST): vol.In(device_selection)}),
         )

--- a/custom_components/senseme/const.py
+++ b/custom_components/senseme/const.py
@@ -4,17 +4,12 @@ DOMAIN = "senseme"
 # Periodic fan update rate in minutes
 UPDATE_RATE = 1
 
-# Options
-CONF_ENABLE_WHOOSH = "enable_whoosh"
-CONF_ENABLE_WHOOSH_DEFAULT = True
-CONF_ENABLE_DIRECTION = "enable_direction"
-CONF_ENABLE_DIRECTION_DEFAULT = True
-
 # config flow
 CONF_DEVICE_INPUT = "device_input"
 
 # data storage
 CONF_INFO = "info"
+CONF_HOST_MANUAL = "IP Address"
 
 # Fan Preset Modes
 PRESET_MODE_NONE = "None"

--- a/custom_components/senseme/strings.json
+++ b/custom_components/senseme/strings.json
@@ -1,19 +1,25 @@
 {
-    "title": "SenseME",
     "config": {
-        "flow_title": "SenseME",
         "step": {
             "user": {
-                "title": "Setup a new Big Ass Fans Haiku device with SenseME",
-                "description": "Start by entering the device name (e.g. Studio or Bedroom) or IP address of the Haiku Device you want to add. If any devices were automatically found on your network, they are shown below.\n\nIf you cannot see your device or experience any issues, try specifying the device IP address.\n\n{devices}",
+                "description": "Select a device, or choose none to manually enter an IP Address.",
                 "data": {
-                    "device_input": "Device"
+                    "host": "Device"
+                }
+            },
+            "manual": {
+                "description": "Enter an IP Address.",
+                "data": {
+                    "host": "[%key:common::config_flow::data::host%]"
                 }
             }
         },
-        "error": {
-            "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+        "abort": {
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        },        
+        "error": {
+            "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
         }
     }
 }

--- a/custom_components/senseme/strings.json
+++ b/custom_components/senseme/strings.json
@@ -3,7 +3,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "Select a device, or choose IP Address to manually enter an IP Address.",
+                "description": "Select a device, or choose 'IP Address' to manually enter an IP Address.",
                 "data": {
                     "host": "Device"
                 }

--- a/custom_components/senseme/strings.json
+++ b/custom_components/senseme/strings.json
@@ -1,8 +1,9 @@
 {
+    "title": "SenseME",
     "config": {
         "step": {
             "user": {
-                "description": "Select a device, or choose none to manually enter an IP Address.",
+                "description": "Select a device, or choose IP Address to manually enter an IP Address.",
                 "data": {
                     "host": "Device"
                 }

--- a/custom_components/senseme/translations/en.json
+++ b/custom_components/senseme/translations/en.json
@@ -1,19 +1,25 @@
 {
     "config": {
-        "error": {
-            "already_configured": "Device is already configured",
-            "no_devices_found": "No devices found on the network"
+        "abort": {
+            "already_configured": "Device is already configured"
         },
-        "flow_title": "SenseME",
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_host": "Invalid hostname or IP address"
+        },
         "step": {
+            "manual": {
+                "data": {
+                    "host": "Host"
+                },
+                "description": "Enter an IP Address."
+            },
             "user": {
                 "data": {
-                    "device_input": "Device"
+                    "host": "Device"
                 },
-                "description": "Start by entering the device name (e.g. Studio or Bedroom) or IP address of the Haiku Device you want to add. If any devices were automatically found on your network, they are shown below.\n\nIf you cannot see your device or experience any issues, try specifying the device IP address.\n\n{devices}",
-                "title": "Setup a new Big Ass Fans Haiku device with SenseME"
+                "description": "Select a device, or choose none to manually enter an IP Address."
             }
         }
-    },
-    "title": "SenseME"
+    }
 }

--- a/custom_components/senseme/translations/en.json
+++ b/custom_components/senseme/translations/en.json
@@ -18,7 +18,7 @@
                 "data": {
                     "host": "Device"
                 },
-                "description": "Select a device, or choose IP Address to manually enter an IP Address."
+                "description": "Select a device, or choose 'IP Address' to manually enter an IP Address."
             }
         }
     },

--- a/custom_components/senseme/translations/en.json
+++ b/custom_components/senseme/translations/en.json
@@ -18,8 +18,9 @@
                 "data": {
                     "host": "Device"
                 },
-                "description": "Select a device, or choose none to manually enter an IP Address."
+                "description": "Select a device, or choose IP Address to manually enter an IP Address."
             }
         }
-    }
+    },
+    "title": "SenseME"
 }


### PR DESCRIPTION
- Allows selection of device in the config flow with a dropdown
- Fallback to manual ip address if no devices discovered or none selected

<img width="456" alt="Screen Shot 2021-02-25 at 10 29 06 PM" src="https://user-images.githubusercontent.com/663432/109255093-ebe0d400-77b8-11eb-9910-0125ee61bb20.png">
<img width="440" alt="Screen Shot 2021-02-25 at 10 29 10 PM" src="https://user-images.githubusercontent.com/663432/109255100-ef745b00-77b8-11eb-80de-579d04678342.png">
<img width="426" alt="Screen Shot 2021-02-25 at 10 29 16 PM" src="https://user-images.githubusercontent.com/663432/109255110-f1d6b500-77b8-11eb-8afc-a863414a67fa.png">
