### PR TITLE
Add support for controlling light and fan motion, move sleep mode to be a switch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,6 @@ name: Push, Pull-Request and cron actions
 
 on:
   push:
-  pull_request:
   schedule:
     - cron: "0 0 * * *"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Home Assistant integration for SenseME fans
 
+## 2.2.2 - Add additional controls
+
+* Sleep Mode is now a separate switch instead of a preset mode.
+* Added Motion switch for fans and lights. Home Assistant can enable/disable SenseME's automatic control of devices when occupancy is detected.
+* Thanks go to [bdraco](https://github.com/bdraco) for these changes!
+
 ## 2.2.1 - Improve documentation for existing users
 
 * No functional changes.
@@ -13,6 +19,7 @@
 * Since whoosh is now a preset mode instead of hidden behind oscillate functionality there was no real need for integrations options so they have been removed.
 * Bump version aiosenseme >= v0.5.2.
 * Sorry but translations have been lost in this release.
+* Thanks go to [bdraco](https://github.com/bdraco) for all the great help in improving this release!
 
 ## 2.1.3 - Add Norwegian translation. Thanks [hwikene](https://github.com/hwikene)
 

--- a/README.md
+++ b/README.md
@@ -53,29 +53,38 @@ When the integration connects to a device it retrieves the *Device Name* you set
     * Supports On/Off.
     * Supports Speed percentage that snaps to possible speeds, usually 7 not including off.
     * Supports Directions Forward and Reverse.
-    * Supports Preset Modes Whoosh and Sleep.
+    * Supports Preset Mode Whoosh.
   * `light` (if it exists) named "*Device Name* Light".
     * Supports Brightness percentage that snaps to possible levels usually 16 not including off.
   * `binary_sensor` (if it exists) named "*Device Name* Occupancy".
+    * Current occupancy status.
     * Device class is occupancy.
+  * `switch` named "*Device Name* Sleep Mode".
+    * Enable/disable sleep mode in fan.
+  * `switch` named "*Device Name* Motion".
+    * Enable/disable automatic control of fan based on occupancy.
+  * `switch` (if it exists) named "*Device Name* Light Motion".
+    * Enable/disable automatic control of fan's light based on occupancy.
 * For lights you get the following platforms:
   * `light` named "*Device Name*".
     * Supports Brightness percentage that snaps to possible light brightness levels usually 16 not including off.
     * Supports Color Temp.
   * `binary_sensor` named "*Device Name* Occupancy".
+    * Current occupancy status.
     * Device class is occupancy.
+  * `switch` named "*Device Name* Sleep Mode".
+    * Enable/disable sleep mode in light.
+  * `switch` named "*Device Name* Motion".
+    * Enable/disable automatic control of light based on occupancy.
 
 ## SenseME platform attributes
 
-* All platforms: (fan, light and binary_sensor)
+* All platforms: (fan, light, binary_sensor and sensor)
   * `room_name`: When the device is associated in a group of devices this will be the name of the room. All devices in the group will have the same name for `room_name`. `room_name` will be *"EMPTY* if the device is not in a room.
   * `room_type`: When the device is associated in a group of devices this will be the type of room. All fans in the group will have the same `room_type`. There 29 room types: *"Undefined"*, *"Other"*, *"Master Bedroom"*, *"Bedroom"*, *"Den"*, *"Family Room"*, *"Living Room"*, *"Kids Room"*, *"Kitchen"*, *"Dining Room"*, *"Basement"*, *"Office"*, *"Patio"*, *"Porch"*, *"Hallway"*, *"Entryway"*, *"Bathroom"*, *"Laundry"*, *"Stairs"*, *"Closet"*, *"Sunroom"*, *"Media Room"*, *"Gym"*, *"Garage"*, *"Outside"*, *"Loft"*, *"Playroom"*, *"Pantry"* and *"Mudroom"*
 * Fan platform
   * `auto_comfort`: Auto Comfort allows the fan to monitor and adjust to room conditions like temperature, humidity and occupancy. There are four possible states: *"Off"*, *"Cooling"*, *"Heating"*, and *"Followtstat"*.
   * `smartmode`: Smartmode indicates the fan's comfort mode. When `auto_comfort` is set to *"Followtstat"* the actual `auto_comfort` value will change based the connected thermostat otherwise `smartmode` tracks `auto_comfort`. There are three possible states: *"Off"*, *"Cooling"* and *"Heating"*.
-  * `motion_control`: is *"On"* when the fan is controlled by the occupancy sensor, *"Off"* otherwise.
-* Light platform
-  * `motion_control`: is *"On"* when the light is controlled by the occupancy sensor, *"Off"* otherwise.
 
 ## SenseME integration options
 

--- a/custom_components/senseme/__init__.py
+++ b/custom_components/senseme/__init__.py
@@ -8,6 +8,7 @@ from aiosenseme import async_get_device_by_device_info
 from homeassistant.components.binary_sensor import DOMAIN as BINARYSENSOR_DOMAIN
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant
@@ -15,7 +16,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONF_INFO, DOMAIN, UPDATE_RATE
 
-PLATFORMS = [FAN_DOMAIN, LIGHT_DOMAIN, BINARYSENSOR_DOMAIN]
+PLATFORMS = [FAN_DOMAIN, LIGHT_DOMAIN, BINARYSENSOR_DOMAIN, SWITCH_DOMAIN]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/senseme/config_flow.py
+++ b/custom_components/senseme/config_flow.py
@@ -1,12 +1,12 @@
 """Config flow for SenseME."""
 import ipaddress
 
+import voluptuous as vol
 from aiosenseme import async_get_device_by_ip_address, discover_all
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
-import voluptuous as vol
 
-from .const import CONF_INFO, CONF_HOST_MANUAL, DOMAIN
+from .const import CONF_HOST_MANUAL, CONF_INFO, DOMAIN
 
 DISCOVER_TIMEOUT = 5
 

--- a/custom_components/senseme/const.py
+++ b/custom_components/senseme/const.py
@@ -12,9 +12,7 @@ CONF_INFO = "info"
 CONF_HOST_MANUAL = "IP Address"
 
 # Fan Preset Modes
-PRESET_MODE_NONE = "None"
 PRESET_MODE_WHOOSH = "Whoosh"
-PRESET_MODE_SLEEP = "Sleep"
 
 # Fan Directions
 SENSEME_DIRECTION_FORWARD = "FWD"

--- a/custom_components/senseme/fan.py
+++ b/custom_components/senseme/fan.py
@@ -19,7 +19,6 @@ from homeassistant.util.percentage import (
 from . import SensemeEntity
 from .const import (
     DOMAIN,
-    PRESET_MODE_SLEEP,
     PRESET_MODE_WHOOSH,
     SENSEME_DIRECTION_FORWARD,
     SENSEME_DIRECTION_REVERSE,
@@ -125,8 +124,7 @@ class HASensemeFan(SensemeEntity, FanEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
         if preset_mode == PRESET_MODE_WHOOSH:
-            # Sleep mode must be turned off
-            # for Whoosh to work.
+            # Sleep mode must be off for Whoosh to work.
             if self._device.sleep_mode:
                 self._device.sleep_mode = False
             self._device.fan_whoosh_mode = True

--- a/custom_components/senseme/light.py
+++ b/custom_components/senseme/light.py
@@ -41,15 +41,6 @@ class HASensemeLight(SensemeEntity, LightEntity):
             self._supported_features |= SUPPORT_COLOR_TEMP
 
     @property
-    def device_state_attributes(self) -> dict:
-        """Get the current device state attributes."""
-        return {
-            "sleep_mode": "On" if self._device.sleep_mode else "Off",
-            "motion_control": "On" if self._device.motion_light_auto else "Off",
-            **super().device_state_attributes,
-        }
-
-    @property
     def unique_id(self) -> str:
         """Return a unique identifier for this light."""
         return f"{self._device.uuid}-LIGHT"

--- a/custom_components/senseme/switch.py
+++ b/custom_components/senseme/switch.py
@@ -19,6 +19,7 @@ FAN_LIGHT_SWITCHES = [
 ]
 
 LIGHT_SWITCHES = [
+    ["sleep_mode", "sleep_mode", "Sleep Mode"],
     ["motion_light_auto", "motion_light_auto", "Motion"],
 ]
 

--- a/custom_components/senseme/switch.py
+++ b/custom_components/senseme/switch.py
@@ -1,0 +1,72 @@
+"""Support for Big Ass Fans SenseME switch."""
+from typing import Any
+
+from aiosenseme import SensemeFan
+from homeassistant.components.switch import DEVICE_CLASS_SWITCH, SwitchEntity
+from homeassistant.const import CONF_DEVICE
+
+from . import SensemeEntity
+from .const import DOMAIN
+
+FAN_SWITCHS = [
+    # Turning on sleep mode will disable Whoosh
+    ["sleep_mode", "sleep_mode", "Sleep Mode"],
+    ["motion_fan_auto", "motion_fan_auto", "Motion"],
+]
+
+FAN_LIGHT_SWITCHES = [
+    ["motion_light_auto", "motion_light_auto", "Light Motion"],
+]
+
+LIGHT_SWITCHES = [
+    ["motion_light_auto", "motion_light_auto", "Motion"],
+]
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up SenseME fans."""
+    device = hass.data[DOMAIN][entry.entry_id][CONF_DEVICE]
+
+    if device.is_fan:
+        async_add_entities([HASensemeSwitch(device, *args) for args in FAN_SWITCHS])
+        if device.has_light:
+            async_add_entities(
+                [HASensemeSwitch(device, *args) for args in FAN_LIGHT_SWITCHES]
+            )
+    elif device.is_light:
+        async_add_entities([HASensemeSwitch(device, *args) for args in LIGHT_SWITCHES])
+
+
+class HASensemeSwitch(SensemeEntity, SwitchEntity):
+    """SenseME switch component."""
+
+    def __init__(
+        self, device: SensemeFan, switch_type: str, attr: str, switch_name: str
+    ) -> None:
+        """Initialize the entity."""
+        self._attr = attr
+        self._switch_type = switch_type
+        super().__init__(device, f"{device.name} {switch_name}")
+
+    @property
+    def device_class(self):
+        """Return an device class for this switch."""
+        return DEVICE_CLASS_SWITCH
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this fan switch."""
+        return f"{self._device.uuid}-SWITCH-{self._switch_type}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        return getattr(self._device, self._attr)
+
+    async def async_turn_on(self, **kwargs: Any):
+        """Turn on the switch."""
+        setattr(self._device, self._attr, True)
+
+    async def async_turn_off(self, **kwargs: Any):
+        """Turn off the switch."""
+        setattr(self._device, self._attr, False)

--- a/custom_components/senseme/version.py
+++ b/custom_components/senseme/version.py
@@ -1,3 +1,3 @@
 """Version for senseme-hacs."""
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/info.md
+++ b/info.md
@@ -1,8 +1,13 @@
 ## SenseME integration
 
 {% if installed %}
+{% if version_installed.replace("v", "").replace(".","") | int >= 220  %}
+{% if version_installed.replace("v", "").replace(".","") | int < 222  %}
+> **Note: Sleep Mode is now controlled by a separate switch instead of the Sleep preset mode.**
+{% endif %}
+{% endif %}
 {% if version_installed.replace("v", "").replace(".","") | int < 220  %}
-> **Important Note: The SenseME integration has had significant changes to the way devices are handled. Previously just adding the integration enabled discovery and would automatically add all found devices to Home Assistant. This is no longer the case. Now you add the SenseME integration for each device you would like Home Assistant to control. You will need to remove the existing SenseME integration from Home Assistant before adding your devices one at a time as discussed below in the Configuration section. It doesn't matter if you remove the integration before or after upgrading the SenseME integration via HACS.**
+> **Important Note: The SenseME integration has had significant changes to the way devices are handled. Previously just adding the integration enabled discovery and would automatically add all found devices to Home Assistant. This is no longer the case. Now you add the SenseME integration for each device you would like Home Assistant to control. Existing users will need to remove the existing SenseME integration from Home Assistant before adding your devices one at a time as discussed below in the Configuration section.**
 {% endif %}
 {% endif %}
 
@@ -19,8 +24,10 @@ Be sure to setup your devices with the Haiku by BAF app before using this integr
 * Supports [Wireless Wall Control](https://www.bigassfans.com/support/haiku-wireless-wall-control/) indirectly through fan status reporting.
 * Probably supports Haiku C fans. If you have a Haiku C fan you might be seeing a warning about an unknown model in the Home Assistant log. Please open an issue [here](https://github.com/mikelawrence/senseme-hacs/issues) to let me know the model name.
 * Haiku Fan supports speed, direction, light and occupancy sensor if available.
-* Haiku Fan whoosh and sleep modes are available as preset modes.
+* Haiku Fan Whoosh is available as a preset mode.
+* Haiku Fan Sleep Mode and Motion control are supported by separate switches.
 * Haiku Light supports brightness, color temp and occupancy sensor.
+* Haiku Light Sleep Mode and Motion control are supported by separate switches.
 * Adding just one of the devices in a room will allow Home Assistant to control all of them.
 
 ### Configuration
@@ -41,4 +48,4 @@ Be sure to setup your devices with the Haiku by BAF app before using this integr
 
 6. Repeat these steps for each device you wish to add.
 
-Selected Version {{ selected_tag }}
+Selected Version {{ selected_tag }}, Installed version {{ version_installed }}


### PR DESCRIPTION
These are not mutually exclusive with the fan being
manually controlled like whoosh so it seems like a
switch better represents them.

HomeKit can now turn on / off the fan since it doesn't
think its already on because it would see the `PRESET_MODE_NONE`
as an `on` state.