### PR TITLE
Improve detection logic for lost connections to devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Home Assistant integration for SenseME fans
 
+## 2.2.3 - Bump aiosenseme library to >= v.5.4
+
+* This improves detection logic for lost connections to devices.
+
 ## 2.2.2 - Add additional controls
 
 * Sleep Mode is now a separate switch instead of a preset mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Home Assistant integration for SenseME fans
 
-## 2.2.3 - Bump aiosenseme library to >= v.5.4
+## 2.2.3 - Bump aiosenseme library to >= v0.5.4
 
 * This improves detection logic for lost connections to devices.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ There are no options for the SenseME integration.
 * Unknown models will produce a warning 'Discovered unknown SenseME device model' in Home Assistant. If you get this warning post an issue on [GitHub](https://github.com/mikelawrence/senseme-hacs/issues) with the model detected and I'll add that model to stop the warning.
 * The occupancy sensor is treated differently than other devices settings/states; occupancy state changes are not pushed immediately and must be detected with periodic status updates. This will make updates to the occupancy sensor sluggish. This sensor in my two fans is a bit erratic. They tend to detect occupancy when there is no one present including pets.
 * Sometimes SenseME devices just don't respond to discovery packets. If you are trying to add the device you can simply use the IP address or you can try a again later when the SenseME devices are more cooperative.
-* SenseME fans will occasionally drop the connection to Home Assistant. The integration will detect this and automatically reconnect. If it was the fan that dropped the connection this integration will usually reconnect within a minute. I'm not sure why but if the fan is powered off it can take a long time to detect the lost connection and that time varies based on what platform Home Assistant Core is running. On my development platform (Windows Subsystem for Linux running Ubuntu) a powered off fan is detected in a couple of minutes. Home Assistant running on a Raspberry Pi takes upwards of 25 minutes to detect lost connections.
 
 ## Debugging
 

--- a/custom_components/senseme/manifest.json
+++ b/custom_components/senseme/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "senseme",
   "name": "SenseME",
-  "version": "2.2.1",
+  "version": "2.2.3",
   "config_flow": true,
   "documentation": "https://www.github.com/mikelawrence/senseme-hacs",
   "issue_tracker": "https://github.com/mikelawrence/senseme-hacs/issues",
@@ -10,6 +10,6 @@
     "@mikelawrence"
   ],
   "requirements": [
-    "aiosenseme>=0.5.2,<0.6.0"
+    "aiosenseme>=0.5.4,<0.6.0"
   ]
 }

--- a/custom_components/senseme/version.py
+++ b/custom_components/senseme/version.py
@@ -1,3 +1,3 @@
 """Version for senseme-hacs."""
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"

--- a/info.md
+++ b/info.md
@@ -47,5 +47,3 @@ Be sure to setup your devices with the Haiku by BAF app before using this integr
    <img src="https://raw.githubusercontent.com/mikelawrence/senseme-hacs/master/img/address.png"/>
 
 6. Repeat these steps for each device you wish to add.
-
-Selected Version {{ selected_tag }}, Installed version {{ version_installed }}


### PR DESCRIPTION
Requiring aiosenseme >= v0.5.4 adds a timeout for status updates. This reduces the lost connection detection time of 15 minutes on some platforms to mere minutes.